### PR TITLE
Closes #27

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ to `possibly_award_badge()`.
 
 If your `Badge.award()` method takes a long time to compute it may be
 prohibitively expensive to call during the request/response cycle.  To solve
-this problem Pinax Badges provides an `async` option to `Badges`.  If this
+this problem Pinax Badges provides an `async_` option to `Badges`.  If this
 is `True` Pinax Badges will defer calling your `award()` method, using
 `celery`, and it will be called at a later time, by another process (read the
 [celery docs](http://celeryproject.org/docs/) for more information on how
@@ -206,7 +206,7 @@ requires some mutable state.
 ```python
     class AddictBadge(Badge):
         # stuff
-        async = True
+        async_ = True
 
         def freeze(self, **state):
             state["current_day"] = datetime.today()

--- a/README.md
+++ b/README.md
@@ -313,6 +313,10 @@ Context data:
 
 ## Change Log
 
+### 2.0.1
+
+* Change Badge.async attribute to Badge.async_ since async is now a keyword in Python 3.7. This was implemented in a backwards compatible way so Badge.async is still valid in older Python versions.
+
 ### 2.0.0
 
 * Add Django 2.0 compatibility testing

--- a/pinax/badges/base.py
+++ b/pinax/badges/base.py
@@ -2,6 +2,14 @@ from .models import BadgeAward
 from .signals import badge_awarded
 
 
+def abstract_property(name):
+    def attr(*args):
+        msg = 'attribute %r must be defined on child class.' % name
+        raise NotImplementedError(msg)
+
+    return property(attr, attr)
+
+
 class BadgeAwarded(object):
     def __init__(self, level=None, user=None):
         self.level = level
@@ -16,6 +24,12 @@ class BadgeDetail(object):
 
 class Badge(object):
     async_ = False
+    multiple = abstract_property('multiple')
+    levels = abstract_property('levels')
+    slug = abstract_property('slug')
+
+    def award(self, **state):
+        raise NotImplementedError('must be implemented on base class')
 
     def __init__(self):
         assert not (self.multiple and len(self.levels) > 1)

--- a/pinax/badges/base.py
+++ b/pinax/badges/base.py
@@ -48,7 +48,7 @@ class Badge(object):
         if awarded.level is None:
             assert len(self.levels) == 1
             awarded.level = 1
-        # awarded levels are 1 indexed, for conveineince
+        # awarded levels are 1 indexed, for convenience
         awarded = awarded.level - 1
         assert awarded < len(self.levels)
         if (

--- a/pinax/badges/base.py
+++ b/pinax/badges/base.py
@@ -15,7 +15,7 @@ class BadgeDetail(object):
 
 
 class Badge(object):
-    async = False
+    async_ = False
 
     def __init__(self):
         assert not (self.multiple and len(self.levels) > 1)
@@ -29,7 +29,7 @@ class Badge(object):
         asynchronous it just queues up the badge awarding.
         """
         assert "user" in state
-        if self.async:
+        if self.async_:
             from .tasks import AsyncBadgeAward
             state = self.freeze(**state)
             AsyncBadgeAward.delay(self, state)
@@ -52,8 +52,8 @@ class Badge(object):
         awarded = awarded.level - 1
         assert awarded < len(self.levels)
         if (
-            not self.multiple and
-            BadgeAward.objects.filter(user=user, slug=self.slug, level=awarded)
+                not self.multiple and
+                BadgeAward.objects.filter(user=user, slug=self.slug, level=awarded)
         ):
             return
         extra_kwargs = {}
@@ -83,3 +83,10 @@ class Badge(object):
 
     def freeze(self, **state):
         return state
+
+
+# Patch badge so badge.async is still available as an attribute on older Python
+# versions.
+setattr(Badge, 'async', property(
+    fget=lambda self: self.async_,
+    fset=lambda self, value: setattr(self, 'async_', value)))

--- a/pinax/badges/base.py
+++ b/pinax/badges/base.py
@@ -4,7 +4,7 @@ from .signals import badge_awarded
 
 def abstract_property(name):
     def attr(*args):
-        msg = 'attribute %r must be defined on child class.' % name
+        msg = "attribute %r must be defined on child class." % name
         raise NotImplementedError(msg)
 
     return property(attr, attr)
@@ -24,12 +24,12 @@ class BadgeDetail(object):
 
 class Badge(object):
     async_ = False
-    multiple = abstract_property('multiple')
-    levels = abstract_property('levels')
-    slug = abstract_property('slug')
+    multiple = abstract_property("multiple")
+    levels = abstract_property("levels")
+    slug = abstract_property("slug")
 
     def award(self, **state):
-        raise NotImplementedError('must be implemented on base class')
+        raise NotImplementedError("must be implemented on base class")
 
     def __init__(self):
         assert not (self.multiple and len(self.levels) > 1)
@@ -101,6 +101,6 @@ class Badge(object):
 
 # Patch badge so badge.async is still available as an attribute on older Python
 # versions.
-setattr(Badge, 'async', property(
+setattr(Badge, "async", property(
     fget=lambda self: self.async_,
-    fset=lambda self, value: setattr(self, 'async_', value)))
+    fset=lambda self, value: setattr(self, "async_", value)))

--- a/pinax/badges/tests/tests.py
+++ b/pinax/badges/tests/tests.py
@@ -82,6 +82,10 @@ class BadgesTests(BaseTestCase):
         self.assertEqual(b.async_, True)
         self.assertEqual(getattr(b, 'async'), True)
 
+    def test_undefined_attribute_error_message(self):
+        with self.assertRaises(NotImplementedError):
+            Badge()
+
 
 class TemplateTagsTests(TestCase):
 

--- a/pinax/badges/tests/tests.py
+++ b/pinax/badges/tests/tests.py
@@ -6,6 +6,7 @@ from django.test import TestCase
 from pinax.badges.base import Badge, BadgeAwarded
 from pinax.badges.registry import badges
 from pinax.badges.templatetags import pinax_badges_tags
+
 from .models import PlayerStat
 
 
@@ -76,11 +77,11 @@ class BadgesTests(BaseTestCase):
     def test_async_attribute(self):
         b = PointsBadge()
         self.assertEqual(b.async_, False)
-        self.assertEqual(getattr(b, 'async'), False)
+        self.assertEqual(getattr(b, "async"), False)
 
-        setattr(b, 'async', True)
+        setattr(b, "async", True)
         self.assertEqual(b.async_, True)
-        self.assertEqual(getattr(b, 'async'), True)
+        self.assertEqual(getattr(b, "async"), True)
 
     def test_undefined_attribute_error_message(self):
         with self.assertRaises(NotImplementedError):

--- a/pinax/badges/tests/tests.py
+++ b/pinax/badges/tests/tests.py
@@ -6,7 +6,6 @@ from django.test import TestCase
 from pinax.badges.base import Badge, BadgeAwarded
 from pinax.badges.registry import badges
 from pinax.badges.templatetags import pinax_badges_tags
-
 from .models import PlayerStat
 
 
@@ -73,6 +72,15 @@ class BadgesTests(BaseTestCase):
         self.assertEqual(u.badges_earned.count(), 1)
 
         self.assert_num_queries(1, lambda: u.badges_earned.get().badge)
+
+    def test_async_attribute(self):
+        b = PointsBadge()
+        self.assertEqual(b.async_, False)
+        self.assertEqual(getattr(b, 'async'), False)
+
+        setattr(b, 'async', True)
+        self.assertEqual(b.async_, True)
+        self.assertEqual(getattr(b, 'async'), True)
 
 
 class TemplateTagsTests(TestCase):

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import find_packages, setup
 
-VERSION = "2.0.0"
+VERSION = "2.0.1"
 LONG_DESCRIPTION = """
 .. image:: http://pinaxproject.com/pinax-design/patches/pinax-badges.svg
     :target: https://pypi.python.org/pypi/pinax-badges/


### PR DESCRIPTION
Changed Badge.async attribute to Badge.async_ since async is now a keyword in Python 3.7.
This was implemented in a backwards compatible way so Badge.async is still valid in older Python versions.