### PR TITLE
Fallback when celery is not installed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,10 +313,13 @@ Context data:
 
 ## Change Log
 
+### 2.0.2
+
+* Don't fail when importing pinax.badges.tasks if celery is not installed.
+
 ### 2.0.1
 
 * Change Badge.async attribute to Badge.async_ since async is now a keyword in Python 3.7. This was implemented in a backwards compatible way so Badge.async is still valid in older Python versions.
-* Don't fail when importing pinax.badges.tasks if celery is not installed.
 
 ### 2.0.0
 

--- a/README.md
+++ b/README.md
@@ -316,6 +316,7 @@ Context data:
 ### 2.0.1
 
 * Change Badge.async attribute to Badge.async_ since async is now a keyword in Python 3.7. This was implemented in a backwards compatible way so Badge.async is still valid in older Python versions.
+* Don't fail when importing pinax.badges.tasks if celery is not installed.
 
 ### 2.0.0
 

--- a/pinax/badges/tasks.py
+++ b/pinax/badges/tasks.py
@@ -1,4 +1,8 @@
-from celery import Task
+try:
+    from celery import Task
+except ImportError:
+    # If celery is not installed, just use a stub base class
+    Task = object
 
 
 class AsyncBadgeAward(Task):

--- a/pinax/badges/tests/tests.py
+++ b/pinax/badges/tests/tests.py
@@ -102,3 +102,13 @@ class TemplateTagsTests(TestCase):
 
     def test_badges_for_user(self):
         self.assertEqual(pinax_badges_tags.badges_for_user(self.user).count(), 1)
+
+
+class TasksTestCase(TestCase):
+
+    def test_import_without_celery(self):
+        # importing pinax.badges.tasks without celery installed should not fail
+        try:
+            import pinax.badges.tasks  # noqa
+        except ImportError:
+            self.fail("Importing pinax.badges.tasks without celery installed should not fail")

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import find_packages, setup
 
-VERSION = "2.0.1"
+VERSION = "2.0.2"
 LONG_DESCRIPTION = """
 .. image:: http://pinaxproject.com/pinax-design/patches/pinax-badges.svg
     :target: https://pypi.python.org/pypi/pinax-badges/


### PR DESCRIPTION
Celery is an optional install for pinax-badges. This change means that importing pinax.badges.tasks does not fail if celery is not installed.

Fixes #31