### PR TITLE
Adding python 3.7 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
   lint:
     <<: *common
     docker:
-      - image: circleci/python:3.6
+      - image: circleci/python:3.7
         environment:
           - TOXENV=checkqa
           - UPLOAD_COVERAGE=0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,6 +80,18 @@ jobs:
       - image: circleci/python:3.6
         environment:
           TOXENV=py36-dj20
+  py37dj111:
+    <<: *common
+    docker:
+      - image: circleci/python:3.7
+        environment:
+          TOXENV=py37-dj111
+  py37dj20:
+    <<: *common
+    docker:
+      - image: circleci/python:3.7
+        environment:
+          TOXENV=py37-dj20
 
 workflows:
   version: 2
@@ -93,3 +105,5 @@ workflows:
       - py35dj20
       - py36dj111
       - py36dj20
+      - py37dj111
+      - py37dj20

--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,9 @@ all: init test
 
 init:
 	python setup.py develop
-	pip install detox coverage
+	pip install tox coverage
 
 test:
 	coverage erase
-	detox
+	tox --parallel
 	coverage html

--- a/README.md
+++ b/README.md
@@ -55,10 +55,10 @@ add badges to a Django project.
 
 #### Supported Django and Python versions
 
-Django \ Python | 2.7 | 3.4 | 3.5 | 3.6
---------------- | --- | --- | --- | ---
-1.11 |  *  |  *  |  *  |  *  
-2.0  |     |  *  |  *  |  *
+Django \ Python | 2.7 | 3.4 | 3.5 | 3.6 | 3.7
+--------------- | --- | --- | --- | --- | ---
+1.11 |  *  |  *  |  *  |  *  |  *  
+2.0  |     |  *  |  *  |  *  |  *
 
 
 ## Documentation
@@ -312,6 +312,11 @@ Context data:
 
 
 ## Change Log
+
+### 2.0.3
+
+* Add Python 3.7 to the support versions matrix due to change made in v2.0.1
+* Change `detox` to `tox --parallel`
 
 ### 2.0.2
 

--- a/setup.py
+++ b/setup.py
@@ -39,13 +39,13 @@ Pinax Badges
 Supported Django and Python Versions
 ------------------------------------
 
-+-----------------+-----+-----+-----+-----+
-| Django / Python | 2.7 | 3.4 | 3.5 | 3.6 |
-+=================+=====+=====+=====+=====+
-|  1.11           |  *  |  *  |  *  |  *  |
-+-----------------+-----+-----+-----+-----+
-|  2.0            |     |  *  |  *  |  *  |
-+-----------------+-----+-----+-----+-----+
++-----------------+-----+-----+-----+-----+-----+
+| Django / Python | 2.7 | 3.4 | 3.5 | 3.6 | 3.7 |
++=================+=====+=====+=====+=====+=====+
+|  1.11           |  *  |  *  |  *  |  *  |  *  |
++-----------------+-----+-----+-----+-----+-----+
+|  2.0            |     |  *  |  *  |  *  |  *  |
++-----------------+-----+-----+-----+-----+-----+
 """
 
 setup(
@@ -71,12 +71,11 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
     install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,8 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
+        'Programming Language :: Python :: 2',	
+        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import find_packages, setup
 
-VERSION = "2.0.2"
+VERSION = "2.0.3"
 LONG_DESCRIPTION = """
 .. image:: http://pinaxproject.com/pinax-design/patches/pinax-badges.svg
     :target: https://pypi.python.org/pypi/pinax-badges/

--- a/tox.ini
+++ b/tox.ini
@@ -32,6 +32,7 @@ envlist =
     py34-dj{111,20}
     py35-dj{111,20}
     py36-dj{111,20}
+    py37-dj{111,20}
 
 [testenv]
 passenv = CI CIRCLECI CIRCLE_*


### PR DESCRIPTION
Changes proposed in this PR:

- Add Python 3.7 to the support versions matrix due to change made in v2.0.1
- Change `detox` to `tox --parallel`