### PR TITLE
Fix async task runner

### DIFF
--- a/pinax/badges/base.py
+++ b/pinax/badges/base.py
@@ -46,7 +46,7 @@ class Badge:
         if self.async_:
             from .tasks import AsyncBadgeAward
             state = self.freeze(**state)
-            AsyncBadgeAward.delay(self, state)
+            AsyncBadgeAward().delay((self, state), serializer="pickle")
             return
         self.actually_possibly_award(**state)
 

--- a/pinax/badges/tasks.py
+++ b/pinax/badges/tasks.py
@@ -1,5 +1,6 @@
 try:
     from celery import Task
+    from celery.registry import tasks
 except ImportError:
     # If celery is not installed, just use a stub base class
     Task = object
@@ -10,3 +11,6 @@ class AsyncBadgeAward(Task):
 
     def run(self, badge, state, **kwargs):
         badge.actually_possibly_award(**state)
+
+
+tasks.register(AsyncBadgeAward)


### PR DESCRIPTION
Closes #41 

Changes proposed in this PR:

The `delay` method on `AsyncBadgeAward` was calling the base `Badge` class and not the actual task.

Fix this by actually instantiating an `AsyncBadgeAward` task and running the `run` method.
Uses the pickle serializer since the JSON serializer can't serialize a `Badge` object.

Also make sure the task is registered with Celery.

Tested with `celery==5.1.2` and `django==3.1.4` on `python==3.7`