### PR TITLE
fix: use gettext_lazy instead of ugettext_lazy

### DIFF
--- a/pinax/badges/apps.py
+++ b/pinax/badges/apps.py
@@ -1,5 +1,5 @@
 from django.apps import AppConfig as BaseAppConfig
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class AppConfig(BaseAppConfig):

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import find_packages, setup
 
-VERSION = "3.0.0"
+VERSION = "3.0.1"
 LONG_DESCRIPTION = """
 .. image:: http://pinaxproject.com/pinax-design/patches/pinax-badges.svg
     :target: https://pypi.python.org/pypi/pinax-badges/


### PR DESCRIPTION
ugettext functions were marked as deprecated in Django 3.0 and removed in 4.0

Changes proposed in this PR:

* use gettext_lazy instead of ugettext_lazy