### PR TITLE
fix: remove providing_args

### DIFF
--- a/pinax/badges/signals.py
+++ b/pinax/badges/signals.py
@@ -1,3 +1,3 @@
 from django.dispatch import Signal
 
-badge_awarded = Signal(providing_args=["badge"])
+badge_awarded = Signal()


### PR DESCRIPTION
removed in Django 4

closes #45